### PR TITLE
tox: run on python 3.8>=

### DIFF
--- a/pyhelper_utils/shell.py
+++ b/pyhelper_utils/shell.py
@@ -1,5 +1,5 @@
 import subprocess
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Tuple
 
 from simple_logger.logger import get_logger
 
@@ -17,7 +17,7 @@ def run_command(
     check: bool = True,
     hide_log_command: bool = False,
     **kwargs: Any,
-) -> tuple[bool, str, str]:
+) -> Tuple[bool, str, str]:
     """
     Run command locally.
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
-envlist = unittests
+envlist = {py38,py39,py310,py311,py312}-{unittest}
 skipsdist = True
 
-[testenv:unittests]
-basepython = python3
+[testenv]
 setenv =
     PYTHONPATH = {toxinidir}
 deps =


### PR DESCRIPTION
Run tox and python 3.8 and up
Fix python 3.8 code compatibility.
