### PR TITLE
Add `raise_final_exception` argument to `ignore_exceptions` decorator

### DIFF
--- a/pyhelper_utils/general.py
+++ b/pyhelper_utils/general.py
@@ -84,6 +84,42 @@ def ignore_exceptions(
     return wrapper
 
 
+def retry_on_exception(
+    retry: int = 0,
+    retry_interval: int = 1,
+    logger: Logger | None = None,
+) -> Any:
+    """
+    Decorator to retry a function on exceptions until the retry limit is reached.
+
+    Args:
+        retry (int): Number of retries to attempt (excluding initial attempt) before throwing an exception.
+        retry_interval (int): Number of seconds to wait between retries.
+        logger (Logger): logger to use, if not passed no logs will be displayed.
+
+    Returns:
+        any: the underline function return value.
+    """
+
+    def wrapper(func: Callable) -> Callable:
+        @wraps(func)
+        def inner(*args: Any, **kwargs: Any) -> Any:
+            for i in range(retry + 1):
+                try:
+                    return func(*args, **kwargs)
+                except Exception as ex:
+                    if i < retry:
+                        sleep(retry_interval)
+                    else:
+                        if logger:
+                            logger.error(f"{func.__name__} error: {ex}")
+                        raise
+
+        return inner
+
+    return wrapper
+
+
 def stt(seconds: int) -> str:
     """
     Convert seconds to human readable time string.

--- a/pyhelper_utils/general.py
+++ b/pyhelper_utils/general.py
@@ -104,11 +104,11 @@ def retry_on_exception(
     def wrapper(func: Callable) -> Callable:
         @wraps(func)
         def inner(*args: Any, **kwargs: Any) -> Any:
-            for i in range(retry + 1):
+            for idx in range(retry + 1):
                 try:
                     return func(*args, **kwargs)
                 except Exception as ex:
-                    if i < retry:
+                    if idx < retry:
                         sleep(retry_interval)
                     else:
                         if logger:

--- a/pyhelper_utils/general.py
+++ b/pyhelper_utils/general.py
@@ -42,21 +42,21 @@ def tts(ts: Any) -> int:
 
 
 def ignore_exceptions(
-    raise_final_exception: bool = False,
     retry: int = 0,
     retry_interval: int = 1,
     return_on_error: Any = None,
     logger: Logger | None = None,
+    raise_final_exception: bool = False,
 ) -> Any:
     """
     Decorator to ignore exceptions with support for retry.
 
     Args:
-        raise_final_exception (bool): whether to raise the final exception.
         retry (int): Number of retry if the underline function throw exception.
         retry_interval (int): Number of seconds to wait between retries.
         return_on_error (Any): Return value if the underline function throw exception.
         logger (Logger): logger to use, if not passed no logs will be displayed.
+        raise_final_exception (bool): whether to raise the final exception.
 
 
     Returns:

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -21,15 +21,6 @@ def func_for_ignore_exception_with_return_value_on_error():
     return _foo
 
 
-@pytest.fixture
-def func_for_ignore_exception_raise_final_exception():
-    @ignore_exceptions(retry=1, retry_interval=1, raise_final_exception=True)
-    def _foo():
-        raise ValueError()
-
-    return _foo
-
-
 def test_tts():
     assert tts("1m") == 60
     assert tts("1h") == 3600
@@ -45,9 +36,13 @@ def test_ignore_exceptions_with_return_value(func_for_ignore_exception_with_retu
     assert func_for_ignore_exception_with_return_value_on_error() == "test"
 
 
-def test_ignore_exception_raise_final_exception(func_for_ignore_exception_raise_final_exception):
+def test_ignore_exception_raise_final_exception():
+    @ignore_exceptions(retry=1, retry_interval=1, raise_final_exception=True)
+    def _foo():
+        raise ValueError()
+
     with pytest.raises(ValueError):
-        func_for_ignore_exception_raise_final_exception()
+        _foo()
 
 
 def test_stt():


### PR DESCRIPTION
- Adds `raise_final_exception` argument to the `ignore_exceptions` decorator. This allows users to retry functions and ignore the exceptions, but will ultimately raise the final exception if all retries have been exhausted.

Adding this in support of https://github.com/RedHatQE/qe-metrics/issues/125