### PR TITLE
fix: types for run_ssh_commands

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,3 +60,12 @@ repos:
         exclude: ^(tests/)
         additional_dependencies: [types-requests]
         args: [--ignore-missing-imports, --disallow-untyped-defs]
+
+  - repo: https://github.com/espressif/conventional-precommit-linter
+    rev: v1.10.0 # The version tag you wish to use
+    hooks:
+      - id: conventional-precommit-linter
+        stages: [commit-msg]
+        args:
+          - --types=ci,docs,feat,fix,refactor,test,release
+          - --subject-min-length=15

--- a/pyhelper_utils/shell.py
+++ b/pyhelper_utils/shell.py
@@ -1,10 +1,12 @@
-import subprocess
-from typing import Any, List, Optional, Tuple
+from __future__ import annotations
 
+import subprocess
+from typing import Any
+
+from rrmngmnt import Host
 from simple_logger.logger import get_logger
 
 from pyhelper_utils.exceptions import CommandExecFailed
-from rrmngmnt import Host
 
 LOGGER = get_logger(name=__name__)
 
@@ -12,16 +14,16 @@ TIMEOUT_30MIN = 30 * 60
 
 
 def run_command(
-    command: List[str],
+    command: list[str],
     verify_stderr: bool = True,
     shell: bool = False,
-    timeout: Optional[int] = None,
+    timeout: int | None = None,
     capture_output: bool = True,
     check: bool = True,
     hide_log_command: bool = False,
     log_errors: bool = True,
     **kwargs: Any,
-) -> Tuple[bool, str, str]:
+) -> tuple[bool, str, str]:
     """
     Run command locally.
 
@@ -83,11 +85,11 @@ def run_command(
 
 def run_ssh_commands(
     host: Host,
-    commands: List[str],
+    commands: list[Any],
     get_pty: bool = False,
     check_rc: bool = True,
     timeout: int = TIMEOUT_30MIN,
-    tcp_timeout: Optional[float] = None,
+    tcp_timeout: float | None = None,
 ) -> list:
     """
     Run commands on remote host via SSH
@@ -110,8 +112,9 @@ def run_ssh_commands(
     Raise:
         CommandExecFailed: If command failed to execute.
     """
-    results: List[str] = []
-    commands_list: List[List[str]] = commands if isinstance(commands[0], list) else [commands]
+    results: list[str] = []
+    commands_list: list[list[str]] = commands if isinstance(commands[0], list) else [commands]
+
     with host.executor().session(timeout=tcp_timeout) as ssh_session:
         for cmd in commands_list:
             rc, out, err = ssh_session.run_cmd(cmd=cmd, get_pty=get_pty, timeout=timeout)


### PR DESCRIPTION
Fix run_ssh_commands `commands` typeing.
Add conventional-precommit-linter for better commit msg.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new commit validation mechanism enforcing commit standards with specific commit types and a minimum subject length.

- **Refactor**
	- Updated internal code practices for enhanced consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->